### PR TITLE
fix: jimp import

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
 		"tslint": "^5.12.1",
 		"tslint-config-standard": "^8.0.1",
 		"typedoc": "^0.14.2",
-		"typescript": "3.2.2"
+		"typescript": "3.6.3"
 	},
 	"private": true,
 	"name": "node-vibrant-monorepo"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 		"pre-commit": "^1.2.2",
 		"rimraf": "^2.6.3",
 		"table": "^5.2.0",
-		"ts-node": "^7.0.1",
+		"ts-node": "^8.4.1",
 		"tsconfig-paths": "^3.7.0",
 		"tslint": "^5.12.1",
 		"tslint-config-standard": "^8.0.1",

--- a/packages/vibrant-image-node/src/index.ts
+++ b/packages/vibrant-image-node/src/index.ts
@@ -27,7 +27,7 @@ const PROTOCOL_HANDLERS: ProtocalHandlerMap = {
 type NodeImageSource = string | Buffer
 
 export default class NodeImage extends ImageBase {
-  private _image: Jimp
+  private _image: typeof Jimp
   private _loadByProtocolHandler (
     handler: ProtocalHandler,
     src: string

--- a/packages/vibrant-image-node/src/index.ts
+++ b/packages/vibrant-image-node/src/index.ts
@@ -5,7 +5,7 @@ import {
   ImageCallback,
   ImageBase
 } from '@vibrant/image'
-import Jimp = require('jimp')
+import Jimp from 'jimp'
 import * as http from 'http'
 import * as https from 'https'
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -58,7 +58,8 @@
     "declaration": true,
     "sourceMap": true,
     "noImplicitAny": true,
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "moduleResolution": "node"
   },
   "include": [
     "packages/*/src",


### PR DESCRIPTION
In my project I get error: `Jimp.read is not a function`, because it was in `Jimp.default.read`, so I pushed a little fix.